### PR TITLE
INF-474/feat: Migrate GitHub Actions runners to vars.RUNNER_STANDARD

### DIFF
--- a/.github/workflows/integrate.yaml
+++ b/.github/workflows/integrate.yaml
@@ -9,7 +9,7 @@ concurrency:
 
 jobs:
     interrogate:
-        runs-on: ubuntu-latest
+        runs-on: ${{ vars.RUNNER_STANDARD }}
         steps:
             - name: Checkout repository
               uses: actions/checkout@v2
@@ -20,7 +20,7 @@ jobs:
                   fail-under: 80
 
     pytest:
-        runs-on: ubuntu-latest
+        runs-on: ${{ vars.RUNNER_STANDARD }}
         steps:
             - name: Check out repository code
               uses: actions/checkout@v2
@@ -41,7 +41,7 @@ jobs:
 
 
     black:
-        runs-on: ubuntu-latest
+        runs-on: ${{ vars.RUNNER_STANDARD }}
         steps:
             - uses: actions/checkout@v2
             - uses: psf/black@stable


### PR DESCRIPTION
Migrates GitHub Actions runner configuration from hardcoded values to organisation variables.

Changes:
- runs-on: self-hosted-standard → ${{ vars.RUNNER_STANDARD }}
- runs-on: self-hosted-highmem → ${{ vars.RUNNER_HIGHMEM }}
- runs-on: self-hosted → ${{ vars.RUNNER_STANDARD }}
- runs-on: ubuntu-latest → ${{ vars.RUNNER_STANDARD }}

Linear: https://linear.app/tillit/issue/INF-474